### PR TITLE
Remove dependencies

### DIFF
--- a/src/scripts/submitToGoogleForms.ts
+++ b/src/scripts/submitToGoogleForms.ts
@@ -1,6 +1,3 @@
-import queryString from 'query-string'
-import axios from 'axios'
-
 import { formatQuestionName, GOOGLE_FORMS_URL } from '../hooks/useGoogleForm'
 import { GoogleForm } from '../types'
 
@@ -8,22 +5,21 @@ export const submitToGoogleForms = async (
   form: GoogleForm,
   formData: object
 ) => {
-  const fields = {}
+  const params = new URLSearchParams()
   Object.keys(formData).forEach((key) => {
-    fields[formatQuestionName(key)] = formData[key]
+    if (formData[key]) {
+      params.append(formatQuestionName(key), formData[key])
+    }
   })
 
-  const params = queryString.stringify(fields, {
-    skipNull: true,
-    skipEmptyString: true
-  })
-
-  return axios.get(
-    `${GOOGLE_FORMS_URL}/${form.action}/formResponse?${params}&submit=Submit`,
+  return fetch(
+    `${GOOGLE_FORMS_URL}/${form.action}/formResponse?${params.toString()}&submit=Submit`,
     {
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded'
-      }
+      },
+      mode: 'no-cors',
+      method: 'GET'
     }
   )
 }


### PR DESCRIPTION
This is the code I am using right now. Works flawlessly.

This could be applied to the useGoogleForm hook as well and then the dependency could be removed.

Let the user decide which fetch fallback they would like to use.