### PR TITLE
Return boolean when submitting to google forms

### DIFF
--- a/src/scripts/__tests__/submitToGoogleForms.spec.ts
+++ b/src/scripts/__tests__/submitToGoogleForms.spec.ts
@@ -1,0 +1,87 @@
+import { GoogleForm } from '../../index'
+import fetch from '../../__mocks__/isomorphic-unfetch'
+import { submitToGoogleForms } from '../submitToGoogleForms'
+
+describe('submitToGoogleForms', () => {
+  const stubForm: GoogleForm = {
+    action: 'action',
+    fvv: 0,
+    pageHistory: 0,
+    fbzx: 'fbzx',
+    fields: [],
+    fieldsOrder: {}
+  }
+  const stubFormData = {
+    id1: 'id1value',
+    id2: 'id2value'
+  }
+
+  afterEach(() => {
+    fetch.mockClear()
+  })
+
+  it('calls google forms with the correct params', async () => {
+    await submitToGoogleForms(stubForm, stubFormData)
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://docs.google.com/forms/d/action/formResponse?submit=Submit&entry.id1=id1value&entry.id2=id2value',
+      {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        method: 'GET',
+        mode: 'no-cors'
+      }
+    )
+  })
+
+  describe('when there is an id that is from custom answer', () => {
+    const stubFormData = {
+      id1: 'id1value',
+      id2: 'id2value',
+      id3: '__other_option__',
+      ['id3-__other_option__-other_option_response']: 'id3value'
+    }
+
+    it('calls google forms with the correct params for the customer answer', async () => {
+      await submitToGoogleForms(stubForm, stubFormData)
+
+      expect(fetch).toHaveBeenCalledWith(
+        'https://docs.google.com/forms/d/action/formResponse?submit=Submit&entry.id1=id1value&entry.id2=id2value&entry.id3=__other_option__&entry.id3.other_option_response=id3value',
+        {
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          method: 'GET',
+          mode: 'no-cors'
+        }
+      )
+    })
+  })
+
+  describe('when the call to google forms is successful', () => {
+    beforeEach(() => {
+      fetch.mockResolvedValue({
+        ok: true,
+        status: 200
+      })
+    })
+
+    it('returns true', async () => {
+      const result = await submitToGoogleForms(stubForm, stubFormData)
+
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('when the call to google forms is not successful', () => {
+    beforeEach(() => {
+      fetch.mockResolvedValue({
+        ok: true,
+        status: 400
+      })
+    })
+
+    it('returns false', async () => {
+      const result = await submitToGoogleForms(stubForm, stubFormData)
+
+      expect(result).toBe(false)
+    })
+  })
+})

--- a/src/scripts/submitToGoogleForms.ts
+++ b/src/scripts/submitToGoogleForms.ts
@@ -21,7 +21,7 @@ export const formatQuestionName = (id: string) => {
 export const submitToGoogleForms = async (
   form: GoogleForm,
   formData: object
-) => {
+): Promise<boolean> => {
   const urlParams = new URLSearchParams()
   Object.keys(formData).forEach((key) => {
     if (formData[key]) {
@@ -41,7 +41,11 @@ export const submitToGoogleForms = async (
       }
     }
   )
-  if (!fetchedResult.ok || fetchedResult.status >= 300) {
-    console.warn('the result of GoogleForm is not correct.', fetchedResult)
-  }
+
+  const wasSuccessful =
+    fetchedResult.ok &&
+    fetchedResult.status < 300 &&
+    fetchedResult.status >= 200
+
+  return wasSuccessful
 }

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -21,7 +21,7 @@ export type GetField = (id: string) => Field
 
 export type UseGoogleFormReturn = UseFormReturn & {
   getField: GetField
-  submitToGoogleForms: (form: FormData) => Promise<void>
+  submitToGoogleForms: (form: FormData) => Promise<boolean>
 }
 
 export type RegisterReturn = {


### PR DESCRIPTION
This PR changes the `submitToGoogleForms` API to return a boolean. This way, clients using this API can have observability of what was the state of submission in order to give some feedback to the user if something goes wrong.

Suggestion by @dohomi on https://github.com/dohomi/react-google-forms-hooks/commit/8a5ff9ed4585e9e8785b8c80b2d9adaa38e74b57
