### PR TITLE
add 17 and 18 react peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
     "deploy": "gh-pages -d example/build"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@testing-library/react-hooks": "^7.0.1",
     "@testing-library/user-event": "^7.2.1",
+    "@testing-library/jest-dom": "^5.14.1",
+    "@testing-library/react": "^12.0.0",
     "@types/jest": "^26.0.24",
     "@types/node": "^12.12.38",
     "@types/react": "^16.9.27",
@@ -65,8 +67,6 @@
     "dist"
   ],
   "dependencies": {
-    "@testing-library/jest-dom": "^5.14.1",
-    "@testing-library/react": "^12.0.0",
     "cheerio": "^1.0.0-rc.10",
     "isomorphic-unfetch": "^3.1.0",
     "react-hook-form": "^7.10.1",


### PR DESCRIPTION
Hello

I just realised a couple of console warnings. I think moving @testing to devDependencies and including react 17 and 18 should be better way for compatibility.