### PR TITLE
Update form.ts to handle null discription

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -9,7 +9,7 @@ export interface CustomizableOption extends Option {
 export interface BaseField {
   id: string
   label: string
-  description?: string
+  description?: string | null
   required: boolean
 }
 


### PR DESCRIPTION
Fixes #33 

#### Issue: When there is no description in Google Forms, the value is set to null. Since the current code only handles description as undefined or a string, TypeScript raises a type incompatibility error.
`Type 'null' is not assignable to type 'string | undefined'.`

#### Solution: Added optional null type to the description field to handle this error.